### PR TITLE
Maintenance: upgrade dependencies and change deployment region

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'artikel-fast'
-primary_region = 'mad'
+primary_region = 'cdg'
 
 [build]
   dockerfile = 'Dockerfile'

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,2 @@
 httpx==0.28.1
-pytest==8.3.4
+pytest==8.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fastapi[standard]==0.115.6
-pydantic-settings==2.7.1
-sqlmodel==0.0.22
+fastapi[standard]==0.115.13
+pydantic-settings==2.9.1
+sqlmodel==0.0.24


### PR DESCRIPTION
`MAD` region is being deprecated, proactively switching over to the recommended `CDG` one.